### PR TITLE
Fixed problem with object's save functionality

### DIFF
--- a/lib/active_record/globalize_accessors.rb
+++ b/lib/active_record/globalize_accessors.rb
@@ -22,7 +22,6 @@ module ActiveRecord
               initialize_temp_attributes unless @temp_attributes
               @temp_attributes[with_locale][attr_name] = val
               globalize.stash.write with_locale, attr_name, val
-              self[attr_name] = val
             end
           end
         end


### PR DESCRIPTION
When saving object, all translation values there overwritten with last localized value in params.
